### PR TITLE
Changes `recording` param type to `Bool?` and sets default value to `nil`.

### DIFF
--- a/Sources/PreviewSnapshotsTesting/PreviewSnapshots+assertSnapshots.swift
+++ b/Sources/PreviewSnapshotsTesting/PreviewSnapshots+assertSnapshots.swift
@@ -32,7 +32,7 @@ extension PreviewSnapshots {
     public func assertSnapshots<Format>(
         as snapshotting: Snapshotting<AnyView, Format>,
         named name: String? = nil,
-        record recording: Bool = false,
+        record recording: Bool? = nil,
         file: StaticString = #file,
         testName: String = #function,
         line: UInt = #line
@@ -65,7 +65,7 @@ extension PreviewSnapshots {
     public func assertSnapshots<Format>(
         as strategies: [String: Snapshotting<AnyView, Format>],
         named name: String? = nil,
-        record recording: Bool = false,
+        record recording: Bool? = nil,
         file: StaticString = #file,
         testName: String = #function,
         line: UInt = #line
@@ -99,7 +99,7 @@ extension PreviewSnapshots {
     public func assertSnapshots<Format>(
         as strategies: [Snapshotting<AnyView, Format>],
         named name: String? = nil,
-        record recording: Bool = false,
+        record recording: Bool? = nil,
         file: StaticString = #file,
         testName: String = #function,
         line: UInt = #line
@@ -151,7 +151,7 @@ extension PreviewSnapshots {
     public func assertSnapshots<Modified: View, Format>(
         as snapshotting: Snapshotting<Modified, Format>,
         named name: String? = nil,
-        record recording: Bool = false,
+        record recording: Bool? = nil,
         file: StaticString = #file,
         testName: String = #function,
         line: UInt = #line,
@@ -202,7 +202,7 @@ extension PreviewSnapshots {
     public func assertSnapshots<Modified: View, Format>(
         as strategies: [String: Snapshotting<Modified, Format>],
         named name: String? = nil,
-        record recording: Bool = false,
+        record recording: Bool? = nil,
         file: StaticString = #file,
         testName: String = #function,
         line: UInt = #line,
@@ -254,7 +254,7 @@ extension PreviewSnapshots {
     public func assertSnapshots<Modified: View, Format>(
         as strategies: [Snapshotting<Modified, Format>],
         named name: String? = nil,
-        record recording: Bool = false,
+        record recording: Bool? = nil,
         file: StaticString = #file,
         testName: String = #function,
         line: UInt = #line,
@@ -292,7 +292,7 @@ extension PreviewSnapshots {
     ///         this function was called.
     public func assertSnapshots(
         named name: String? = nil,
-        record recording: Bool = false,
+        record recording: Bool? = nil,
         file: StaticString = #file,
         testName: String = #function,
         line: UInt = #line
@@ -333,7 +333,7 @@ extension PreviewSnapshots {
     ///   - modify: A closure to update the preview content before snapshotting.
     public func assertSnapshots<Modified: View>(
         named name: String? = nil,
-        record recording: Bool = false,
+        record recording: Bool? = nil,
         file: StaticString = #file,
         testName: String = #function,
         line: UInt = #line,


### PR DESCRIPTION
The `recording` parameter in the [swift-snapshot-testing](https://github.com/pointfreeco/swift-snapshot-testing/blob/main/Sources/SnapshotTesting/AssertSnapshot.swift#L106) framework is of type `Bool?` with a default value of `nil`.
However, the current implementation in [swiftui-preview-snapshots](https://github.com/doordash-oss/swiftui-preview-snapshots) uses a non-optional `Bool` with a default value of `false`. This prevents the `SnapshotTestingConfiguration.Record` parameter from being overridden via the `withSnapshotTesting` configuration tool, as described in the documentation.

As a result, applying the proposed code snippets has no effect in practice.
```
// Record all snapshot failures in a Swift Testing suite:
@Suite(.snapshots(record: .failed))
struct FeatureTests {}

// Record all snapshot failures in an 'XCTestCase' subclass:
class FeatureTests: XCTestCase {
  override func invokeTest() {
    withSnapshotTesting(record: .failed) {
      super.invokeTest()
    }
  }
}
```